### PR TITLE
Dev/make Makefile周りの改善

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ BS:=md
 COMMON_BASE:=$(DEFAULT_YAML) $(realpath Makefile)
 
 # pandoc command
-PANDOC_CMD=pandoc $(PANDOCOPT) $< -o $@
+PANDOC_CMD=(cd $(dir $<) && pandoc $(PANDOCOPT) $(notdir $<) -o $(abspath $(@)))
 # PANDOC_CMD=touch $@
 
 # Silent

--- a/Makefile
+++ b/Makefile
@@ -1,90 +1,149 @@
-SHELL=/bin/bash
+# Fixed assignments.
+# ..............................................................
+# Shell type.
+SHELL:=/bin/bash
 
-PDFROOT:=pdf
-INTROOT:=int
+# Base directories.
 SRCROOT:=md
+INTROOT:=int
+DSTROOT:=pdf
 
-PANDOCOPT+=-d default.yaml
-# pandoc additiona options
-# '-M codeBlockCaptions' and '-M listings' cannot be added
-# from default.yaml
-PANDOCOPT+=-M codeBlockCaptions -M listings
-# Generate pdf command
-PANDOC_MD2PDF=pandoc $(PANDOCOPT) $< -o $@
+# pandoc arguments.
+DEFAULT_YAML:=$(realpath default.yaml)
+PANDOCOPT:=-d $(DEFAULT_YAML)
 
-# For debug.
-# PANDOC_MD2PDF=cp $< $@
+# pandoc-crossref metadatas.
+# These dose not work in default.yaml
+PANDOCOPT+= \
+	-M codeBlockCaptions \
+	-M listings
+
+# Book directory suffix
+BS:=md
+
+# All files dependend files
+COMMON_BASE:=$(DEFAULT_YAML) $(realpath Makefile)
+
+# pandoc command
+PANDOC_CMD=pandoc $(PANDOCOPT) $< -o $@
+# PANDOC_CMD=touch $@
+
+# Silent
 V:=@
+# V:=
 
-# All dirs in srcroot.
-# ..............................................................
-SRCDIRS:=$(shell find $(SRCROOT) -name '.?*' -prune -o -type d)
+# default rule
+default: all
 
-# The dir containing file with this suffix build a pdf by concatenating the all
-# md files instead of build one pdf on one md file.
-# ..............................................................
-CATSUFFIX:=meta
-# Dirs to build single pdf.
-CSUFFILES:=$(strip $(foreach dir,$(SRCDIRS),$(firstword $(wildcard $(dir)/*.$(CATSUFFIX)))))
-CMDDIRS:=$(shell test -n "$(CSUFFILES)" && dirname $(CSUFFILES))
-# src files
-CMDSRCFILES:=$(foreach dir,$(CMDDIRS),$(wildcard $(dir)/*.md))
-# Int files
-CMDFILES:=$(CSUFFILES:$(SRCROOT)%.$(CATSUFFIX)=$(INTROOT)%.mdc)
-# target files
-CPDFFILES:=$(CMDFILES:$(INTROOT)%.mdc=$(PDFROOT)%.pdf)
+#################################################################
+# Automatic calculation below here
+#################################################################
 
-# Dirs to build one pdf on one md files.
-# ..............................................................
-# dir list
-SMDDIRS:=$(filter-out $(CMDDIRS),$(SRCDIRS))
-# src files
-SMDFILES:=$(foreach dir,$(SMDDIRS),$(wildcard $(dir)/*.md))
-# target files
-SPDFFILES:=$(SMDFILES:$(SRCROOT)%.md=$(PDFROOT)%.pdf)
+# Book DIRS to create one PDF.
+BMD_S_DIRS:=$(shell find $(SRCROOT) -name '.?*' \
+	-prune -o -type d -name "*.$(BS)" ! -path "*.$(BS)/*" -print)
+# Book MD intermediate files.
+BMD_I_FILES:=$(foreach dir,$(BMD_S_DIRS),$(dir:$(SRCROOT)%=$(INTROOT)%/book.md))
+# Book pdf files.
+BPDF_D_FILES:=$(BMD_S_DIRS:$(SRCROOT)%.$(BS)=$(DSTROOT)%.pdf)
+
+# Single md files dir.
+SMD_S_DIRS:=$(shell find $(SRCROOT) \( -name '.?*' -o -name "*.$(BS)" \) \
+	-prune -o -type d -print)
+# Single md files.
+SMD_S_FILES:=$(shell find $(SMD_S_DIRS) -maxdepth 1 -type f -name '*.md')
+# Single pdf files.
+SPDF_D_FILES:=$(SMD_S_FILES:$(SRCROOT)%.md=$(DSTROOT)%.pdf)
+
+# All source files.
+SRC_FILES:=$(SMD_S_FILES)
+
+
+#################################################################
+# Macro
+#################################################################
+# BMD_S_DIRS => BMD_I_FILES => BMD_D_FILES
+# $1 = A book directory name with $(BS) suffix
+define book_gen_rule
+# Copy assets files to intermediate. (for estensible)
+# Rule for $(SRCROOT)/**/%.$(BS)/**/% => $(INTROOT)/**/%.$(BS)/**/%
+INT_DIR_$(1):=$(1:$(SRCROOT)/%=$(INTROOT)/%)
+$$(INT_DIR_$(1))/%:$(1)/% $(COMMON_BASE)
+	@echo "@@@@   SUBSGEN [$$@] <= [$$<]"
+	@$$(V)mkdir -p $$(dir $$@)
+	@$$(V)cp $$< $$@
+# Concatnate md files to intermediate.
+# Rule for $(SRCROOT)/**/%.$(BS)/*.md => $(INTROOT)/**/%.$(BS)/book.md
+SRC_MDS_$(1):=$(shell find $(1) -maxdepth 1 -type f -name "*.md")
+INT_MD_$(1):=$$(INT_DIR_$(1))/book.md
+$$(INT_MD_$(1)):$$(SRC_MDS_$(1)) $(COMMON_BASE)
+	@echo "@@@@   IMDGEN [$$@] <= [$$(SRC_MDS_$(1))]"
+	$$(V)mkdir -p $$(dir $$@)
+	$$(V)if [[ -n "$$(SRC_MDS_$(1))" ]]; then\
+		cat $$(SRC_MDS_$(1)) > $$@;\
+	else\
+		touch $$@;\
+	fi
+# Build pdf.
+# Rule for $(INTROOT)/**/%.$(BS)/book.md => $(DSTROOT)/**/%.pdf
+SRC_SUBS_$(1):=$(shell find $(1) -mindepth 2 -type f)
+INT_SUBS_$(1):=$$(SRC_SUBS_$(1):$(SRCROOT)/%=$(INTROOT)/%)
+DST_PDF_$(1):=$(1:$(SRCROOT)/%.$(BS)=$(DSTROOT)/%.pdf)
+$$(DST_PDF_$(1)):$$(INT_MD_$(1)) $$(INT_SUBS_$(1)) $(COMMON_BASE)
+	@echo "@@@@ PDFGEN [$$@] <= [$$(INT_MD_$(1)) $$(INT_SUBS_$(1))]"
+	$$(V)mkdir -p $$(dir $$@)
+	$$(V)$$(PANDOC_CMD)
+
+# Union of source files for hash calculation.
+SRC_FILES+=$$(SRC_SUBS_$(1)) $$(SRC_MDS_$(1))
+
+# for Debugging
+debug_$(1):
+	@echo "@@@@ debug_$(1) ::"
+	@echo "@@@@ INT_DIR   : $$(INT_DIR_$(1))"
+	@echo "@@@@ SRC_MDS   : $$(SRC_MDS_$(1))"
+	@echo "@@@@ INT_MD    : $$(INT_MD_$(1))"
+	@echo "@@@@ SRC_SUBS  : $$(SRC_SUBS_$(1))"
+	@echo "@@@@ INT_SUBS  : $$(INT_SUBS_$(1))"
+	@echo "@@@@ DST_PDF   : $$(DST_PDF_$(1))"
+endef
 
 ################################################################
-MDC?=/dev/null
+# Rules
+################################################################
+.PHONY: default all debug force $(DEBUG_TARGET)
 
-.PHONY: all clean cleanall
-.SECONDARY: $(CMDFILES)
+all: $(BPDF_D_FILES) $(SPDF_D_FILES)
 
-all: $(SPDFFILES) $(CPDFFILES)
+# Rule generate for
+# Rule for $(SRCROOT)/**/%.$(BS)/**/% => $(INTROOT)/**/%.$(BS)/**/%
+# Rule for $(SRCROOT)/**/%.$(BS)/*.md => $(INTROOT)/**/%.$(BS)/book.md
+# Rule for $(INTROOT)/**/%.$(BS)/book.md => $(DSTROOT)/**/%.pdf
+$(foreach dir,$(BMD_S_DIRS),$(eval $(call book_gen_rule,$(dir))))
 
-$(PDFROOT)/%.pdf:$(INTROOT)/%.mdc
+# create single pdf
+$(DSTROOT)/%.pdf:$(SRCROOT)/%.md $(COMMON_BASE)
+	@echo "@@@@ PDFGEN [$@] <= [$<]"
 	$(V)mkdir -p $(dir $@)
-	@echo "@@@@ $< => $@"
-	$(V)$(PANDOC_MD2PDF)
-
-$(PDFROOT)/%.pdf:$(SRCROOT)/%.md
-	$(V)mkdir -p $(dir $@)
-	@echo "@@@@ $< => $@"
-	$(V)$(PANDOC_MD2PDF)
-
-$(INTROOT)/%.mdc: $(CMDSRCFILES)
-	$(V)$(MAKE) -s $(shell dirname $@) MDC=$@
-
-$(INTROOT)/%: $(SRCROOT)/%/*.md
-	$(V)mkdir -p $@
-	@echo "@@@@ $(sort $^) => $(MDC)"
-	cat $(sort $^) > $(MDC)
+	$(V)$(PANDOC_CMD)
 
 cleanall: clean
-	rm -rf $(PDFROOT)
+	rm -rf $(DSTROOT)
 
 clean:
 	rm -rf $(INTROOT)
 
-hash:
-	@cat $(CMDSRCFILES) $(SMDFILES) | md5sum -
+hash: $(SRC_FILES) $(COMMON_BASE)
+	@cat $^ | md5sum -
 
-debug:
-	@echo "==== single markdowns"
-	@echo SMDDIRS..:$(SMDDIRS)
-	@echo SMDFILES.:$(SMDFILES)
-	@echo SPDFFILES:$(SPDFFILES)
-	@echo "==== concat markdowns"
-	@echo "CSUFFILES:$(CSUFFILES)"
-	@echo "CMDSRCFILES:$(CMDSRCFILES)"
-	@echo "CMDDIRS..:$(CMDDIRS)"
-	@echo "CMDFILES.:$(CMDFILES)"
+# Debug target
+DEBUG_TARGET:=$(foreach dir,$(BMD_S_DIRS),debug_$(dir))
+debug: $(DEBUG_TARGET)
+	@echo "@@@@ BMD_S_DIRS    : $(BMD_S_DIRS)"
+	@echo "@@@@ BMD_I_FILES   : $(BMD_I_FILES)"
+	@echo "@@@@ BPDF_D_FILES  : $(BPDF_D_FILES)"
+	@echo "@@@@ SMD_S_DIRS    : $(SMD_S_DIRS)"
+	@echo "@@@@ SMD_S_FILES   : $(SMD_S_FILES)"
+	@echo "@@@@ SPDF_D_FILES  : $(SPDF_D_FILES)"
+	@echo "@@@@ SRC_FILES     : $(SRC_FILES)"
+	@echo "@@@@ DEBUG_TARGET  : $(DEBUG_TARGET)"

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ SRCDIRS:=$(shell find $(SRCROOT) -name '.?*' -prune -o -type d)
 CATSUFFIX:=meta
 # Dirs to build single pdf.
 CSUFFILES:=$(strip $(foreach dir,$(SRCDIRS),$(firstword $(wildcard $(dir)/*.$(CATSUFFIX)))))
-CMDDIRS:=$(shell dirname $(CSUFFILES))
+CMDDIRS:=$(shell test -n "$(CSUFFILES)" && dirname $(CSUFFILES))
 # src files
 CMDSRCFILES:=$(foreach dir,$(CMDDIRS),$(wildcard $(dir)/*.md))
 # Int files
@@ -76,7 +76,7 @@ clean:
 	rm -rf $(INTROOT)
 
 hash:
-	@cat $(CMDSRCFILES) $(SMDFILES) | md5sum
+	@cat $(CMDSRCFILES) $(SMDFILES) | md5sum -
 
 debug:
 	@echo "==== single markdowns"

--- a/auto-run.sh
+++ b/auto-run.sh
@@ -10,9 +10,6 @@ errexit() {
 }
 
 main() {
-  # subprocess kill when exit
-  trap exittrap EXIT
-
   type inotifywait >& /dev/null \
     || errexit 'Not found inotifywait !! To install "sudo apt install inotify-tools".'
 
@@ -31,6 +28,8 @@ main() {
     make -j 4
     post=$(make hash)
 
+    echo "checksum: pre :$pre"
+    echo "checksum: post:$post"
     if [[ "${pre}" == "${post}" ]]; then
       # Create Watch target. refine evry wait.
       local filelist=($(find . -name '.?*' -prune -o \


### PR DESCRIPTION
Makefile周りの改善

* pandocコマンドを実行する前に変換前のファイルがあるディレクトリに移動するよう改善。
画像など、相対パスで記載されたファイルを変換後のファイルへ含めることができるようになった。

* ファイル分割モードの仕様変更
特定のファイルが存在するディレクトリではなく、特定のサフィックス($(BS))を持ったディレクトリ直下のmarkdownファイルを結合するように変更。
