### PR TITLE
Dev/import template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*~
+md
+pdf
+.work

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "templates/pandoc-latex-template"]
+	path = templates/pandoc-latex-template
+	url = https://github.com/tdoioka/pandoc-latex-template.git

--- a/Makefile
+++ b/Makefile
@@ -10,18 +10,18 @@ DSTROOT:=pdf
 
 # base files.
 DEFAULT_YAML:=$(realpath default.yaml)
+CROSSREF_YAML:=$(realpath crossref.yaml)
 TEMPLATE_TEX:=$(realpath templates/pandoc-latex-template/eisvogel.tex)
 # All files dependend files
-COMMON_BASE:=$(realpath Makefile) $(DEFAULT_YAML) $(TEMPLATE_TEX)
+COMMON_BASE:=$(realpath Makefile) $(DEFAULT_YAML) $(CROSSREF_YAML) \
+	$(TEMPLATE_TEX)
 
 # pandoc arguments, use template.
 PANDOCOPT:=-d $(DEFAULT_YAML)
 
-# pandoc-crossref metadatas.
-# These dose not work in default.yaml
-PANDOCOPT+= \
-	-M codeBlockCaptions \
-	-M listings
+# Set pandoc-crossref options
+PANDOCOPT+=--filter pandoc-crossref -M "crossrefYaml=$(CROSSREF_YAML)"
+
 ifdef TEMPLATE_TEX
 PANDOCOPT+=--template=$(TEMPLATE_TEX)
 endif

--- a/crossref.yaml
+++ b/crossref.yaml
@@ -1,0 +1,41 @@
+# General options
+# ..............................................................
+
+# If True, latex export will use \cref from cleveref package.
+# Only relevant for LaTeX output. \usepackage{cleveref} will be
+# automatically added to header-includes.
+# cref: True
+
+# If True, number elements as chapter.item, and restart item on
+# each first-level heading. You might also need to run pandoc
+# with --top-level-division=chapter argument to signal it you
+# want to use chapters; whether it’s actually required or nt
+# depends on the output format, but it’s always safe to include.
+# Notice chapters and related options are ignored in LaTeX
+# output. See Note on LaTeX and chapters option
+# chapters: True
+
+# default 1: header level to treat as “chapter”. If
+# chaptersDepth>1, then items will be prefixed with several
+# numbers, corresponding to header numbers, e.g. fig. 1.4.3.
+# chaptersDepth: 2
+
+# If True, parse table-style code block captions.
+codeBlockCaptions: True
+
+# If True, generate code blocks for listings package. Only
+# relevant for LaTeX output. \usepackage{listings} will be
+# automatically added to header-includes. You need to specify
+# --listings option as well.
+listings: True
+
+# ..............................................................
+
+figureTitle: "図"
+tableTitle: "表"
+listingTitle: "コード"
+titleDelim: ":"
+figPrefix: "図"
+eqnPrefix: "式"
+tblPrefix: "表"
+lstPrefix: "コード"

--- a/default.yaml
+++ b/default.yaml
@@ -5,13 +5,12 @@
 #   definition_lists : use definition list
 from: markdown+ignore_line_breaks+footnotes+definition_lists
 pdf-engine: lualatex
-template: eisvogel
 
 filters:
   # Use crossref filtter
   - pandoc-crossref
 
-variables:
+metadata:
   # CJK(Chinese,Japanese,Korean) main font.
   CJKmainfont: IPAexGothic
   # Title page variables.
@@ -19,6 +18,13 @@ variables:
   titlepage-rule-color: 53565a
   # TOC page standalone.
   toc-own-page: true
+  # Centering captions.
+  caption-justification: centering
+  # ToC Title
+  toc-title: 目次
+  # ................
+  # Changelog
+  changelog-title: 更新履歴
 
 # Numbering chapters.
 number-sections: true

--- a/default.yaml
+++ b/default.yaml
@@ -6,10 +6,6 @@
 from: markdown+ignore_line_breaks+footnotes+definition_lists
 pdf-engine: lualatex
 
-filters:
-  # Use crossref filtter
-  - pandoc-crossref
-
 metadata:
   # CJK(Chinese,Japanese,Korean) main font.
   CJKmainfont: IPAexGothic
@@ -36,8 +32,3 @@ toc-depth: 3
 # Code highlighting.
 highlight-style: tango
 listings: true
-## Can't add to yuml instead of argument.
-## There are effect to code block
-# metadata:
-#   - codeBlockCaptions
-#   - listings


### PR DESCRIPTION
* サブモジュールとして `Wandmalfarbe/pandoc-latex-template`から`fork`した`tdoioka/pandoc-latex-template`を追加。
これはには下記の機能を追加している。
  * pandoc-crossrefのキャプション名変更を有効化した
  * ToCの前にChangeLogの設定があれば追加する

* pandoc-crossref の設定をMakefileとdefault.yamlからcrossref.yamlへ移動
