### PR TITLE
Work/make Makefileの改善

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 
 # rootdir
 /md
+/int
 /pdf
 /.work

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ SOUT_D_FILES:=$(foreach \
 
 # All source files.
 SRC_FILES:=$(SMD_S_FILES)
-
+SRC_DIRS:=$(shell find $(SRCROOT) -name '.?*' -prune -o -type d -print)
 
 #################################################################
 # Macro
@@ -158,6 +158,9 @@ clean:
 
 hash: $(SRC_FILES) $(COMMON_BASE)
 	@cat $^ | md5sum -
+
+srclist:
+	@echo $(SRC_DIRS) $(SRC_FILES) $(COMMON_BASE)
 
 # Debug target
 DEBUG_TARGET:=$(foreach dir,$(BMD_S_DIRS),debug_$(dir))

--- a/auto-run.sh
+++ b/auto-run.sh
@@ -9,13 +9,6 @@ errexit() {
   exit 1
 }
 
-genflist() {
-  find . \( -name '.?*' -o -name 'templates' \) -prune -o -type d -print
-  find templates -name '*.tex' -type f
-  find . \( -name '.?*' -o -name 'templates' \) -prune -o -type f \
-       \( -name '*.md' -o -name 'Makefile' -o -name '*.yaml' \) -print
-}
-
 main() {
   type inotifywait >& /dev/null \
     || errexit 'Not found inotifywait !! To install "sudo apt install inotify-tools".'
@@ -39,7 +32,7 @@ main() {
     echo "checksum: post:$post"
     if [[ "${pre}" == "${post}" ]]; then
       # Create Watch target. refine evry wait.
-      local filelist=($(genflist))
+      local filelist=($(make srclist))
       # Waiting file changes
       echo -e "Waiting [${events[@]}]: ${filelist[@]}\n\n"
       inotifywait ${argev[@]} ${filelist[@]} \

--- a/auto-run.sh
+++ b/auto-run.sh
@@ -9,6 +9,13 @@ errexit() {
   exit 1
 }
 
+genflist() {
+  find . \( -name '.?*' -o -name 'templates' \) -prune -o -type d -print
+  find templates -name '*.tex' -type f
+  find . \( -name '.?*' -o -name 'templates' \) -prune -o -type f \
+       \( -name '*.md' -o -name 'Makefile' -o -name '*.yaml' \) -print
+}
+
 main() {
   type inotifywait >& /dev/null \
     || errexit 'Not found inotifywait !! To install "sudo apt install inotify-tools".'
@@ -32,12 +39,7 @@ main() {
     echo "checksum: post:$post"
     if [[ "${pre}" == "${post}" ]]; then
       # Create Watch target. refine evry wait.
-      local filelist=($(find . -name '.?*' -prune -o \
-                             -type d -print))
-      for pt in '*.md' 'Makefile' '*.yaml' '*.yml'; do
-        filelist+=($(find . -name '.?*' -prune -o \
-                          -type f -name "$pt" -print))
-      done
+      local filelist=($(genflist))
       # Waiting file changes
       echo -e "Waiting [${events[@]}]: ${filelist[@]}\n\n"
       inotifywait ${argev[@]} ${filelist[@]} \


### PR DESCRIPTION
* `Makefile`に合わせ、`.gitignore` に、`int`ディレクトリを追加
* `Makefile`で2つ以上のフォーマットを出力できるように修正
  * 例えば`OUTSUFFIXS`に`tex`と`pdf`を設定すれば、`tex`のソースファイルと変換結果の`pdf`が手に入る
* `Makefile`の依存ファイルを`auto-run.sh`がリストアップするのではなく`Makefile`に自身にリストアップさせるように変更